### PR TITLE
fixed building

### DIFF
--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -70,28 +70,205 @@ jobs:
           choco install unzip -y
         }
 
-    - name: Install OpenSSL 1.1.x
+    - name: Install OpenSSL 1.1.x to current directory
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
-        # Prefer an explicit 1.1.x version. Adjust if your org feed has a different last 1.1 build.
-        choco install openssl --version=1.1.1.2000 -y -r `
-          || choco install openssl --version=1.1.1.1400 -y -r `
-          || choco install openssl11 -y -r
+        
+        # Get current working directory 
+        $currentDir = (Get-Location).Path
+        $opensslDir = Join-Path $currentDir "OpenSSL-Win64"
+        
+        Write-Host "Installing OpenSSL 1.1.x to: $opensslDir"
+        
+        # Create directory if it doesn't exist
+        New-Item -Path $opensslDir -ItemType Directory -Force | Out-Null
+        
+        # Install OpenSSL with custom directory using install arguments
+        # The /DIR= parameter is passed to the underlying installer
+        try {
+          choco install openssl --version=1.1.1.1400 -y --force --install-arguments="'/DIR=$opensslDir'"
+        } catch {
+          Write-Host "First attempt failed, trying with different approach..."
+          try {
+            choco install openssl11 -y --force --install-arguments="'/DIR=$opensslDir'"
+          } catch {
+            Write-Host "Second attempt failed, trying openssl.light..."
+            choco install openssl.light -y --force --install-arguments="'/DIR=$opensslDir'"
+          }
+        }
+        
+        Write-Host "Installation completed. Checking results..."
+        
+        # Verify installation
+        if (Test-Path $opensslDir) {
+          Write-Host "✓ OpenSSL installed successfully to: $opensslDir"
+          Write-Host "Directory contents:"
+          Get-ChildItem $opensslDir -Recurse | Select-Object -First 20 | ForEach-Object { 
+            Write-Host "  $($_.FullName)" 
+          }
+        } else {
+          Write-Host "✗ Installation may have failed. Searching for OpenSSL..."
+          # Search for any OpenSSL installation
+          $found = Get-ChildItem $currentDir -Recurse -Directory -Name "*OpenSSL*" -ErrorAction SilentlyContinue
+          if ($found) {
+            Write-Host "Found OpenSSL directories: $($found -join ', ')"
+          }
+        }
 
-    - name: Debug Write host listing out what's in OpenSSL paths
+    - name: Enhanced Debug - Find OpenSSL DLLs
       shell: pwsh
       run: |
-        $roots = @(
-          "C:\Program Files\OpenSSL-Win64\bin",
-          "C:\Program Files\OpenSSL-Win64\"
-        ) | Where-Object { Test-Path $_ }
+        Write-Host "=== Searching for OpenSSL 1.1 DLLs ==="
         
-        Write-Host "Roots to check: $($roots -join ', ')"
+        $currentDir = (Get-Location).Path
+        $searchPaths = @(
+          "$currentDir\OpenSSL-Win64",
+          "$currentDir\OpenSSL-Win64\bin", 
+          "$currentDir\OpenSSL",
+          "$currentDir\OpenSSL\bin"
+        )
         
-        foreach ($r in $roots) {
-          Write-Host "Contents of ${r}:"
-          Get-ChildItem $r -Recurse | ForEach-Object { Write-Host $_.FullName }
+        # Add any directories we find that contain OpenSSL
+        $foundDirs = Get-ChildItem $currentDir -Recurse -Directory -Name "*OpenSSL*" -ErrorAction SilentlyContinue
+        foreach ($dir in $foundDirs) {
+          $fullPath = Join-Path $currentDir $dir
+          $searchPaths += $fullPath
+          $searchPaths += Join-Path $fullPath "bin"
+        }
+        
+        $dlls = @('libcrypto-1_1-x64.dll', 'libssl-1_1-x64.dll')
+        $foundDlls = @{}
+        
+        foreach ($dll in $dlls) {
+          Write-Host "`nSearching for $dll..."
+          foreach ($path in $searchPaths) {
+            if (Test-Path $path) {
+              $found = Get-ChildItem $path -Filter $dll -ErrorAction SilentlyContinue
+              if ($found) {
+                Write-Host "  ✓ Found: $($found.FullName)"
+                $foundDlls[$dll] = $found.FullName
+                break
+              }
+            }
+          }
+          if (-not $foundDlls.ContainsKey($dll)) {
+            Write-Host "  ✗ $dll not found in expected locations"
+          }
+        }
+        
+        # If not found in expected locations, search the entire current directory tree
+        foreach ($dll in $dlls) {
+          if (-not $foundDlls.ContainsKey($dll)) {
+            Write-Host "Performing broader search for $dll..."
+            $found = Get-ChildItem $currentDir -Recurse -Filter $dll -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($found) {
+              Write-Host "  ✓ Found via broad search: $($found.FullName)"
+              $foundDlls[$dll] = $found.FullName
+            }
+          }
+        }
+        
+        Write-Host "`n=== Search Summary ==="
+        foreach ($dll in $dlls) {
+          if ($foundDlls.ContainsKey($dll)) {
+            Write-Host "✓ $dll : $($foundDlls[$dll])"
+          } else {
+            Write-Host "✗ $dll : NOT FOUND"
+          }
+        }
+
+    - name: Bundle OpenSSL 1.1 DLLs (Fixed)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        
+        # Destination = the already-existing build output folder
+        $dest = "$(Resolve-Path 'aseprite/build/bin')"
+        $currentDir = (Get-Location).Path
+        
+        # Search paths in the current directory
+        $searchPaths = @(
+          "$currentDir\OpenSSL-Win64\bin",
+          "$currentDir\OpenSSL-Win64", 
+          "$currentDir\OpenSSL\bin",
+          "$currentDir\OpenSSL"
+        )
+        
+        # Add any OpenSSL directories we can find
+        $opensslDirs = Get-ChildItem $currentDir -Recurse -Directory -Name "*OpenSSL*" -ErrorAction SilentlyContinue
+        foreach ($dir in $opensslDirs) {
+          $fullPath = Join-Path $currentDir $dir
+          $searchPaths += $fullPath
+          $searchPaths += Join-Path $fullPath "bin"
+        }
+        
+        # Filter to only existing paths
+        $existingPaths = $searchPaths | Where-Object { Test-Path $_ }
+        
+        Write-Host "Searching in paths: $($existingPaths -join ', ')"
+        
+        $crypto = $null
+        $ssl = $null
+        
+        # Search for the DLLs
+        foreach ($path in $existingPaths) {
+          if (-not $crypto) { 
+            $crypto = Get-ChildItem $path -Recurse -Filter 'libcrypto-1_1-x64.dll' -ErrorAction SilentlyContinue | Select-Object -First 1 
+          }
+          if (-not $ssl) { 
+            $ssl = Get-ChildItem $path -Recurse -Filter 'libssl-1_1-x64.dll' -ErrorAction SilentlyContinue | Select-Object -First 1 
+          }
+          
+          # Break early if we found both
+          if ($crypto -and $ssl) { break }
+        }
+        
+        # If still not found, search the entire current directory tree (last resort)
+        if (-not $crypto) {
+          Write-Host "Performing broad search for libcrypto-1_1-x64.dll..."
+          $crypto = Get-ChildItem $currentDir -Recurse -Filter 'libcrypto-1_1-x64.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
+        if (-not $ssl) {
+          Write-Host "Performing broad search for libssl-1_1-x64.dll..."
+          $ssl = Get-ChildItem $currentDir -Recurse -Filter 'libssl-1_1-x64.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
+        
+        # Check if we found everything
+        if (-not $crypto -or -not $ssl) { 
+          Write-Host "ERROR: Could not find required OpenSSL 1.1 DLLs"
+          Write-Host "Crypto DLL: $(if($crypto) { $crypto.FullName } else { 'NOT FOUND' })"
+          Write-Host "SSL DLL: $(if($ssl) { $ssl.FullName } else { 'NOT FOUND' })"
+          
+          # List all DLLs we can find for debugging
+          Write-Host "`nAll DLLs found in current directory:"
+          Get-ChildItem $currentDir -Recurse -Filter "*.dll" -ErrorAction SilentlyContinue | 
+            Where-Object { $_.Name -like "*ssl*" -or $_.Name -like "*crypto*" } |
+            ForEach-Object { Write-Host "  $($_.FullName)" }
+            
+          throw "Could not find OpenSSL 1.1 DLLs"
+        }
+
+        Write-Host "Found DLLs:"
+        Write-Host "  Crypto: $($crypto.FullName)"
+        Write-Host "  SSL: $($ssl.FullName)"
+
+        # Copy the DLLs
+        Copy-Item $crypto.FullName -Destination $dest -Force
+        Copy-Item $ssl.FullName -Destination $dest -Force
+        
+        Write-Host "✓ Successfully bundled OpenSSL DLLs into $dest"
+        
+        # Verify the files were copied
+        $copiedCrypto = Join-Path $dest $crypto.Name
+        $copiedSsl = Join-Path $dest $ssl.Name
+        
+        if ((Test-Path $copiedCrypto) -and (Test-Path $copiedSsl)) {
+          Write-Host "✓ Verification: DLLs successfully copied to destination"
+          Write-Host "  $copiedCrypto"
+          Write-Host "  $copiedSsl"
+        } else {
+          throw "Verification failed: DLLs were not copied successfully"
         }
 
     - name: Clone Aseprite

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches: [ main, master, beta ]
   pull_request:
     branches: [ main, master, beta ]
   workflow_dispatch:

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -416,24 +416,28 @@ jobs:
           throw "Verification failed: DLLs were not copied successfully"
         }
 
-    - name: Package Artifacts
-      shell: bash
+    - name: Package Artifacts (Windows zip via PowerShell)
+      shell: pwsh
       run: |
-        cd aseprite
-        ARTIFACT_DIR="aseprite-windows-${{ env.BUILD_TYPE }}"
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
         
-        # Copy binaries
-        cp -r build/bin "$ARTIFACT_DIR"
+        Push-Location aseprite
+        $artifactDir = "aseprite-windows-${{ env.BUILD_TYPE }}"
         
-        # Create info file
-        cat > "$ARTIFACT_DIR/BUILD_INFO.txt" << EOF
+        if (Test-Path $artifactDir) { Remove-Item $artifactDir -Recurse -Force }
+        New-Item -ItemType Directory -Path $artifactDir | Out-Null
+        
+        Copy-Item -Recurse -Force "build/bin" $artifactDir
+        
+        $buildInfo = @"
         Aseprite Build Information
         ==========================
         Branch: ${{ env.BRANCH }}
         Base Branch: ${{ steps.skia-version.outputs.BASE_BRANCH }}
         Build Type: ${{ env.BUILD_TYPE }}
         Skia Version: ${{ steps.skia-version.outputs.SKIA_TAG }}
-        Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+        Build Date: $(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
         Commit: $(git rev-parse HEAD)
         
         To run Aseprite:
@@ -442,10 +446,13 @@ jobs:
         
         Note: This is an unofficial build. Consider purchasing Aseprite
         from https://www.aseprite.org/ to support the developers.
-        EOF
+        "@
+        Set-Content -Path (Join-Path $artifactDir "BUILD_INFO.txt") -Value $buildInfo -NoNewline
         
-        # Create ZIP archive (bsdtar supports zip format on Windows)
-        tar -c --format=zip -f aseprite-windows-${{ env.BUILD_TYPE }}.zip "$ARTIFACT_DIR"
+        $zipPath = "aseprite-windows-${{ env.BUILD_TYPE }}.zip"
+        if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+        Compress-Archive -Path "$artifactDir\*" -DestinationPath $zipPath -CompressionLevel Optimal
+        Pop-Location
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -70,6 +70,152 @@ jobs:
           choco install unzip -y
         }
 
+    - name: Clone Aseprite
+      shell: bash
+      run: |
+        git clone --recursive https://github.com/aseprite/aseprite.git
+        cd aseprite
+        
+        # Checkout specific branch if specified
+        if [ "${{ env.BRANCH }}" != "main" ]; then
+          git fetch --all --tags
+          git checkout ${{ env.BRANCH }}
+        fi
+        
+        # Update submodules
+        git submodule update --init --recursive
+
+    - name: Detect Skia Version
+      id: skia-version
+      shell: bash
+      run: |
+        cd aseprite
+        
+        # Get the required Skia tag from laf/misc/skia-tag.txt
+        if [ -f "laf/misc/skia-tag.txt" ]; then
+          SKIA_TAG=$(cat laf/misc/skia-tag.txt)
+          echo "Found Skia tag: $SKIA_TAG"
+        else
+          # Fallback to m124 if file doesn't exist
+          SKIA_TAG="m124-08a5439a6b"
+          echo "Using default Skia tag: $SKIA_TAG"
+        fi
+        
+        # Extract the Skia directory name (e.g., m124 from m124-08a5439a6b)
+        SKIA_DIR_NAME="skia-$(echo $SKIA_TAG | cut -d '-' -f 1)"
+        
+        echo "SKIA_TAG=$SKIA_TAG" >> $GITHUB_OUTPUT
+        echo "SKIA_DIR_NAME=$SKIA_DIR_NAME" >> $GITHUB_OUTPUT
+        
+        # Determine branch type for base branch detection
+        BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+        if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == "beta" ]]; then
+          BASE_BRANCH="$BRANCH_NAME"
+        else
+          # Check if this branch is based on beta or main
+          if git branch --contains origin/beta | grep -q "^\* $BRANCH_NAME\$" 2>/dev/null; then
+            BASE_BRANCH="beta"
+          else
+            BASE_BRANCH="main"
+          fi
+        fi
+        echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_OUTPUT
+
+    - name: Cache Skia
+      id: cache-skia
+      uses: actions/cache@v4
+      with:
+        path: C:/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
+        key: skia-${{ steps.skia-version.outputs.SKIA_TAG }}-windows-${{ env.BUILD_TYPE }}-v3
+
+    - name: Download Skia
+      if: steps.cache-skia.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd aseprite
+        
+        # Create deps directory
+        mkdir -p /c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
+        cd /c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
+        
+        # Determine which Skia build to download
+        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
+          SKIA_BUILD="Debug"
+        else
+          SKIA_BUILD="Release"
+        fi
+        
+        # Get the Skia URL using the laf script
+        if [ -f "$GITHUB_WORKSPACE/aseprite/laf/misc/skia-url.sh" ]; then
+          SKIA_URL=$(bash $GITHUB_WORKSPACE/aseprite/laf/misc/skia-url.sh $SKIA_BUILD)
+        else
+          # Fallback URL construction if script doesn't exist
+          SKIA_URL="https://github.com/aseprite/skia/releases/download/${{ steps.skia-version.outputs.SKIA_TAG }}/Skia-Windows-${SKIA_BUILD}-x64.zip"
+        fi
+        
+        echo "Downloading Skia from: $SKIA_URL"
+        SKIA_FILE=$(basename $SKIA_URL)
+        
+        # Download Skia
+        curl --ssl-revoke-best-effort -L -o "$SKIA_FILE" "$SKIA_URL"
+        
+        # Extract Skia
+        unzip -n "$SKIA_FILE"
+        
+        # Verify extraction
+        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
+          EXPECTED_DIR="out/Debug-x64"
+        else
+          EXPECTED_DIR="out/Release-x64"
+        fi
+        
+        if [ ! -d "$EXPECTED_DIR" ]; then
+          echo "Error: Expected Skia directory $EXPECTED_DIR not found after extraction"
+          ls -la
+          exit 1
+        fi
+        
+        echo "Skia downloaded and extracted successfully"
+
+    - name: Configure with CMake
+      shell: bash
+      run: |
+        cd aseprite
+        
+        # Set up paths
+        SOURCE_DIR="$PWD"
+        BUILD_DIR="$PWD/build"
+        SKIA_DIR="/c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}"
+        
+        # Determine Skia library directory based on build type
+        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
+          SKIA_LIBRARY_DIR="$SKIA_DIR/out/Debug-x64"
+        else
+          SKIA_LIBRARY_DIR="$SKIA_DIR/out/Release-x64"
+        fi
+        
+        echo "======================== CONFIGURATION ========================"
+        echo "Build type: ${{ env.BUILD_TYPE }}"
+        echo "Build dir: $BUILD_DIR"
+        echo "Source dir: $SOURCE_DIR"
+        echo "Skia dir: $SKIA_DIR"
+        echo "Skia library dir: $SKIA_LIBRARY_DIR"
+        echo "Branch: ${{ steps.skia-version.outputs.BASE_BRANCH }}"
+        
+        # Run CMake configuration (following build.sh pattern)
+        cmake -B "$BUILD_DIR" -S "$SOURCE_DIR" -G Ninja \
+              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+              -DLAF_BACKEND=skia \
+              -DSKIA_DIR="$SKIA_DIR" \
+              -DSKIA_LIBRARY_DIR="$SKIA_LIBRARY_DIR"
+
+    - name: Build Aseprite
+      shell: bash
+      run: |
+        cd aseprite
+        echo "============================== BUILDING =============================="
+        cmake --build build -- aseprite
+
     - name: Install OpenSSL 1.1.x to current directory
       shell: pwsh
       run: |
@@ -271,191 +417,6 @@ jobs:
           throw "Verification failed: DLLs were not copied successfully"
         }
 
-    - name: Clone Aseprite
-      shell: bash
-      run: |
-        git clone --recursive https://github.com/aseprite/aseprite.git
-        cd aseprite
-        
-        # Checkout specific branch if specified
-        if [ "${{ env.BRANCH }}" != "main" ]; then
-          git fetch --all --tags
-          git checkout ${{ env.BRANCH }}
-        fi
-        
-        # Update submodules
-        git submodule update --init --recursive
-
-    - name: Detect Skia Version
-      id: skia-version
-      shell: bash
-      run: |
-        cd aseprite
-        
-        # Get the required Skia tag from laf/misc/skia-tag.txt
-        if [ -f "laf/misc/skia-tag.txt" ]; then
-          SKIA_TAG=$(cat laf/misc/skia-tag.txt)
-          echo "Found Skia tag: $SKIA_TAG"
-        else
-          # Fallback to m124 if file doesn't exist
-          SKIA_TAG="m124-08a5439a6b"
-          echo "Using default Skia tag: $SKIA_TAG"
-        fi
-        
-        # Extract the Skia directory name (e.g., m124 from m124-08a5439a6b)
-        SKIA_DIR_NAME="skia-$(echo $SKIA_TAG | cut -d '-' -f 1)"
-        
-        echo "SKIA_TAG=$SKIA_TAG" >> $GITHUB_OUTPUT
-        echo "SKIA_DIR_NAME=$SKIA_DIR_NAME" >> $GITHUB_OUTPUT
-        
-        # Determine branch type for base branch detection
-        BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-        if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == "beta" ]]; then
-          BASE_BRANCH="$BRANCH_NAME"
-        else
-          # Check if this branch is based on beta or main
-          if git branch --contains origin/beta | grep -q "^\* $BRANCH_NAME\$" 2>/dev/null; then
-            BASE_BRANCH="beta"
-          else
-            BASE_BRANCH="main"
-          fi
-        fi
-        echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_OUTPUT
-
-    - name: Cache Skia
-      id: cache-skia
-      uses: actions/cache@v4
-      with:
-        path: C:/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
-        key: skia-${{ steps.skia-version.outputs.SKIA_TAG }}-windows-${{ env.BUILD_TYPE }}-v3
-
-    - name: Download Skia
-      if: steps.cache-skia.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd aseprite
-        
-        # Create deps directory
-        mkdir -p /c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
-        cd /c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}
-        
-        # Determine which Skia build to download
-        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
-          SKIA_BUILD="Debug"
-        else
-          SKIA_BUILD="Release"
-        fi
-        
-        # Get the Skia URL using the laf script
-        if [ -f "$GITHUB_WORKSPACE/aseprite/laf/misc/skia-url.sh" ]; then
-          SKIA_URL=$(bash $GITHUB_WORKSPACE/aseprite/laf/misc/skia-url.sh $SKIA_BUILD)
-        else
-          # Fallback URL construction if script doesn't exist
-          SKIA_URL="https://github.com/aseprite/skia/releases/download/${{ steps.skia-version.outputs.SKIA_TAG }}/Skia-Windows-${SKIA_BUILD}-x64.zip"
-        fi
-        
-        echo "Downloading Skia from: $SKIA_URL"
-        SKIA_FILE=$(basename $SKIA_URL)
-        
-        # Download Skia
-        curl --ssl-revoke-best-effort -L -o "$SKIA_FILE" "$SKIA_URL"
-        
-        # Extract Skia
-        unzip -n "$SKIA_FILE"
-        
-        # Verify extraction
-        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
-          EXPECTED_DIR="out/Debug-x64"
-        else
-          EXPECTED_DIR="out/Release-x64"
-        fi
-        
-        if [ ! -d "$EXPECTED_DIR" ]; then
-          echo "Error: Expected Skia directory $EXPECTED_DIR not found after extraction"
-          ls -la
-          exit 1
-        fi
-        
-        echo "Skia downloaded and extracted successfully"
-
-    - name: Configure with CMake
-      shell: bash
-      run: |
-        cd aseprite
-        
-        # Set up paths
-        SOURCE_DIR="$PWD"
-        BUILD_DIR="$PWD/build"
-        SKIA_DIR="/c/deps/${{ steps.skia-version.outputs.SKIA_DIR_NAME }}"
-        
-        # Determine Skia library directory based on build type
-        if [[ "${{ env.BUILD_TYPE }}" == "Debug" ]]; then
-          SKIA_LIBRARY_DIR="$SKIA_DIR/out/Debug-x64"
-        else
-          SKIA_LIBRARY_DIR="$SKIA_DIR/out/Release-x64"
-        fi
-        
-        echo "======================== CONFIGURATION ========================"
-        echo "Build type: ${{ env.BUILD_TYPE }}"
-        echo "Build dir: $BUILD_DIR"
-        echo "Source dir: $SOURCE_DIR"
-        echo "Skia dir: $SKIA_DIR"
-        echo "Skia library dir: $SKIA_LIBRARY_DIR"
-        echo "Branch: ${{ steps.skia-version.outputs.BASE_BRANCH }}"
-        
-        # Run CMake configuration (following build.sh pattern)
-        cmake -B "$BUILD_DIR" -S "$SOURCE_DIR" -G Ninja \
-              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-              -DLAF_BACKEND=skia \
-              -DSKIA_DIR="$SKIA_DIR" \
-              -DSKIA_LIBRARY_DIR="$SKIA_LIBRARY_DIR"
-
-    - name: Build Aseprite
-      shell: bash
-      run: |
-        cd aseprite
-        echo "============================== BUILDING =============================="
-        cmake --build build -- aseprite
-
-    - name: Test Build
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd aseprite/build/bin
-        echo "Testing aseprite.exe..."
-        if [ -f "aseprite.exe" ]; then
-          echo "Aseprite executable found"
-          ls -la aseprite.exe
-          # Try to get version (may fail without display)
-          ./aseprite.exe --version || echo "Version check failed (expected without display)"
-        else
-          echo "ERROR: aseprite.exe not found!"
-          ls -la
-          exit 1
-
-    - name: Bundle OpenSSL 1.1 DLLs
-      shell: pwsh
-      run: |
-            $ErrorActionPreference = 'Stop'
-            # Destination = the already-existing build output folder
-            $dest = "$(Resolve-Path 'aseprite/build/bin')"
-
-            # Where OpenSSL 1.1 was installed
-            $roots = @(
-            "C:\Program Files\OpenSSL-Win64\bin",
-            "C:\Program Files\OpenSSL-Win64\"
-            ) | Where-Object { Test-Path $_ }
-
-            $crypto = $null; $ssl = $null
-            foreach ($r in $roots) {
-            if (-not $crypto) { $crypto = Get-ChildItem $r -Recurse -Filter 'libcrypto-1_1-x64.dll' -ErrorAction SilentlyContinue | Select-Object -First 1 }
-            if (-not $ssl)    { $ssl    = Get-ChildItem $r -Recurse -Filter 'libssl-1_1-x64.dll'    -ErrorAction SilentlyContinue | Select-Object -First 1 }
-            }
-            if (-not $crypto -or -not $ssl) { throw "Could not find OpenSSL 1.1 DLLs" }
-
-            Copy-Item $crypto.FullName -Destination $dest -Force
-            Copy-Item $ssl.FullName    -Destination $dest -Force
-            Write-Host "Bundled into $dest"
     - name: Package Artifacts
       shell: bash
       run: |

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -69,6 +69,30 @@ jobs:
           choco install unzip -y
         }
 
+    - name: Install OpenSSL 1.1.x
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        # Prefer an explicit 1.1.x version. Adjust if your org feed has a different last 1.1 build.
+        choco install openssl --version=1.1.1.2000 -y -r `
+          || choco install openssl --version=1.1.1.1400 -y -r `
+          || choco install openssl11 -y -r
+
+    - name: Debug Write host listing out what's in OpenSSL paths
+      shell: pwsh
+      run: |
+        $roots = @(
+          "C:\Program Files\OpenSSL-Win64\bin",
+          "C:\Program Files\OpenSSL-Win64\"
+        ) | Where-Object { Test-Path $_ }
+        
+        Write-Host "Roots to check: $($roots -join ', ')"
+        
+        foreach ($r in $roots) {
+          Write-Host "Contents of ${r}:"
+          Get-ChildItem $r -Recurse | ForEach-Object { Write-Host $_.FullName }
+        }
+          
     - name: Clone Aseprite
       shell: bash
       run: |
@@ -230,28 +254,6 @@ jobs:
           echo "ERROR: aseprite.exe not found!"
           ls -la
           exit 1
-    
-    - name: Install OpenSSL 1.1.x
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
-        # Prefer an explicit 1.1.x version. Adjust if your org feed has a different last 1.1 build.
-        choco install openssl --version=1.1.1.2000 -y -r `
-          || choco install openssl --version=1.1.1.1400 -y -r `
-          || choco install openssl11 -y -r
-
-    - name: Debug Write host listing out what's in OpenSSL paths
-      shell: pwsh
-      run: |
-        $roots = @(
-          "C:\Program Files\OpenSSL-Win64\bin",
-          "C:\Program Files\OpenSSL-Win64\"
-        ) | Where-Object { Test-Path $_ }
-        
-        foreach ($r in $roots) {
-          Write-Host "Contents of ${r}:"
-          Get-ChildItem $r -Recurse | ForEach-Object { Write-Host $_.FullName }
-        }
 
     - name: Bundle OpenSSL 1.1 DLLs
       shell: pwsh

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+    branches: [ main, master, beta ]
   pull_request:
     branches: [ main, master, beta ]
   workflow_dispatch:
@@ -92,7 +93,7 @@ jobs:
           Write-Host "Contents of ${r}:"
           Get-ChildItem $r -Recurse | ForEach-Object { Write-Host $_.FullName }
         }
-          
+
     - name: Clone Aseprite
       shell: bash
       run: |

--- a/.github/workflows/build-aseprite.yml
+++ b/.github/workflows/build-aseprite.yml
@@ -249,7 +249,7 @@ jobs:
         ) | Where-Object { Test-Path $_ }
         
         foreach ($r in $roots) {
-          Write-Host "Contents of $r:"
+          Write-Host "Contents of ${r}:"
           Get-ChildItem $r -Recurse | ForEach-Object { Write-Host $_.FullName }
         }
 


### PR DESCRIPTION
This pull request significantly improves the Windows build workflow for Aseprite by making the installation and bundling of OpenSSL 1.1 DLLs more robust, enhancing debugging, and switching artifact packaging to PowerShell for better reliability. The changes ensure that OpenSSL dependencies are reliably found and included, and that the resulting artifacts are packaged in a more Windows-native way.

**OpenSSL Installation and Bundling Improvements:**
- Replaces the generic OpenSSL installation with a custom PowerShell step that installs OpenSSL 1.1.x directly into the current working directory, tries multiple fallback options, and verifies installation success.
- Adds enhanced PowerShell debugging steps to locate OpenSSL DLLs (`libcrypto-1_1-x64.dll` and `libssl-1_1-x64.dll`) across all possible directories in the workspace, including broad recursive searches if needed.
- Refactors the bundling step to robustly search for and copy the required OpenSSL DLLs into the build output, with verification and clear error messages if the DLLs are missing.

**Packaging and Artifact Handling:**
- Replaces the previous Bash-based artifact packaging with a PowerShell-based approach, using `Compress-Archive` to create a zip file and generating the `BUILD_INFO.txt` file with PowerShell, ensuring better compatibility and reliability on Windows runners. [[1]](diffhunk://#diff-df66e57f0dcaa93be4cab92a155b1721aaa52b4662b59d2f54f935dcae7a9cb6L218-R440) [[2]](diffhunk://#diff-df66e57f0dcaa93be4cab92a155b1721aaa52b4662b59d2f54f935dcae7a9cb6L305-R455)

**Workflow Cleanup:**
- Removes the obsolete "Test Build" step and the old Bash-based packaging step, streamlining the workflow for clarity and maintainability.